### PR TITLE
Change USB Device Name + Serial No.

### DIFF
--- a/cvpal/usb_config.h
+++ b/cvpal/usb_config.h
@@ -251,14 +251,14 @@ section at the end of this file).
  * obdev's free shared VID/PID pair. See the file USB-IDs-for-free.txt for
  * details.
  */
-#define USB_CFG_DEVICE_NAME     'C', 'V', 'p', 'a', 'l'
-#define USB_CFG_DEVICE_NAME_LEN 5
+#define USB_CFG_DEVICE_NAME      'X', '0', 'X', 'p', 'a', 'l'
+#define USB_CFG_DEVICE_NAME_LEN 6
 /* Same as above for the device name. If you don't want a device name, undefine
  * the macros. See the file USB-IDs-for-free.txt before you assign a name if
  * you use a shared VID/PID.
  */
-#define USB_CFG_SERIAL_NUMBER   'C', 'V', 'p', 'a', 'l', ' ', '1', '.', '0'
-#define USB_CFG_SERIAL_NUMBER_LEN   9
+#define USB_CFG_SERIAL_NUMBER   'X', '0', 'X', 'p', 'a', 'l', ' ', '1', '.', '0'
+#define USB_CFG_SERIAL_NUMBER_LEN   10
 /* Same as above for the serial number. If you don't want a serial number,
  * undefine the macros.
  * It may be useful to provide the serial number through other means than at


### PR DESCRIPTION
Changed USB Device Name and Serial Number strings so module can be used
at same time as CVpal with standard firmware.
